### PR TITLE
Fix Python version docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-        - 3.11
+        - 3.9
   comprehensive-tests:
     runs-on: ubuntu-latest
     services:

--- a/.github/workflows/ci.yml.bak
+++ b/.github/workflows/ci.yml.bak
@@ -54,7 +54,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-        - 3.11
+        - 3.9
   comprehensive-tests:
     runs-on: ubuntu-latest
     services:

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ See [ARCHITECTURE.md](./docs/ARCHITECTURE.md) for system design and dependencies
 ## Development Setup
 
 ### Prerequisites
-- Python 3.11+
+- Python 3.9+
 - Node.js 18+
 - PostgreSQL 15+
 - Redis (optional, for caching)


### PR DESCRIPTION
## Summary
- update README to require Python 3.9+
- keep CI matrix consistent with Python 3.9

## Testing
- `pytest -q tests/test_quote_service.py` *(fails: `pytest` not found)*