### PR TITLE
Fix API client env variable

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -96,7 +96,7 @@ npm run build:prod
 
 The application uses the following environment variables:
 
-- `VITE_API_URL`: The URL of the API server
+- `VITE_API_URL`: Base URL of the API server (used by `src/api/client.ts`)
 - `VITE_APP_NAME`: The name of the application
 - `VITE_APP_VERSION`: The version of the application
 - `VITE_USE_MOCKS`: Whether to use mock data (true/false)
@@ -475,7 +475,7 @@ The authentication system has been enhanced with:
 Create a `.env.local` file:
 
 ```env
-VITE_API_URL=http://localhost:8000
+VITE_API_URL=http://localhost:8000   # Backend base URL
 VITE_APP_NAME=AUL Quote App
 ```
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -4,7 +4,7 @@
 
 import axios from 'axios';
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api/v1';
+const API_BASE_URL = import.meta.env.VITE_API_URL || '/api/v1';
 
 // Create axios instance
 const apiClient = axios.create({


### PR DESCRIPTION
## Summary
- use `VITE_API_URL` in the frontend API client
- document API URL env variable in frontend README

## Testing
- `yarn workspace @aul-quote-app/frontend test` *(fails: package not present in lockfile)*