### PR TITLE
Fix duration parsing bug

### DIFF
--- a/tests/test_duration_parsing.py
+++ b/tests/test_duration_parsing.py
@@ -1,0 +1,22 @@
+import unittest
+from unittest.mock import MagicMock
+
+from warehouse_quote_app.app.services.conversation.conversation_state import ConversationContext
+
+class TestDurationParsing(unittest.TestCase):
+    def test_medium_term_duration(self):
+        # Setup conversation context with mocked services
+        convo = ConversationContext(db=MagicMock(), quote_service=MagicMock(), storage_service=MagicMock())
+        convo.state = 'duration'
+        convo.gathered_info = {}
+
+        # Mock quote service calculate_quote to avoid errors
+        convo.quote_service.calculate_quote.return_value = MagicMock()
+
+        # Provide medium term duration input
+        response = convo.handle_input('I need storage for 3-6 months')
+
+        self.assertEqual(convo.gathered_info['duration_weeks'], 6)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/warehouse_quote_app/app/services/conversation/conversation_state.py
+++ b/warehouse_quote_app/app/services/conversation/conversation_state.py
@@ -46,10 +46,7 @@ class ConversationContext:
         elif self.state == 'duration':
             return self._handle_duration_input(user_input)
         else:
-            return ConversationResponse(
-                messages=["I'm not sure how to proceed. Let's start over."],
-                suggested_responses=["Start over"]
-            )
+            return self._create_error_response()
     
     def _handle_initial_input(self, user_input: str) -> ConversationResponse:
         """Handle initial user request."""
@@ -121,7 +118,7 @@ class ConversationContext:
         # Map duration input to weeks
         if 'short' in user_input or '1-3' in user_input:
             self.gathered_info['duration_weeks'] = 2
-        elif 'medium' in user_input or '1-6' in user_input:
+        elif 'medium' in user_input or '3-6' in user_input:
             self.gathered_info['duration_weeks'] = 6
         elif 'long' in user_input or '6+' in user_input:
             self.gathered_info['duration_weeks'] = 12


### PR DESCRIPTION
## Summary
- fix fallback error response in conversation handler
- fix detection of medium-term durations
- add a regression test for duration parsing

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*