### PR TITLE
Fix README dev script links

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,7 +586,7 @@ The project includes a centralized development toolset:
    .\run.ps1 build
    ```
 
-For detailed development documentation, see [Development Tools Guide](scripts/dev/README.md).
+For detailed development documentation, see [Development Tools Guide](deployment/scripts/README.md).
 
 ## Development Scripts
 
@@ -1083,7 +1083,7 @@ The project includes a centralized development toolset:
    .\run.ps1 build
    ```
 
-For detailed development documentation, see [Development Tools Guide](scripts/dev/README.md).
+For detailed development documentation, see [Development Tools Guide](deployment/scripts/README.md).
 
 ## Development Scripts
 

--- a/README.md
+++ b/README.md
@@ -586,7 +586,7 @@ The project includes a centralized development toolset:
    .\run.ps1 build
    ```
 
-For detailed development documentation, see [Development Tools Guide](deployment/scripts/README.md).
+For detailed development documentation, see [Development Tools Guide](deployment/scripts/dev/README.md).
 
 ## Development Scripts
 

--- a/README.md
+++ b/README.md
@@ -1083,7 +1083,7 @@ The project includes a centralized development toolset:
    .\run.ps1 build
    ```
 
-For detailed development documentation, see [Development Tools Guide](deployment/scripts/README.md).
+For detailed development documentation, see [Development Tools Guide](deployment/scripts/dev/README.md).
 
 ## Development Scripts
 


### PR DESCRIPTION
## Summary
- update README links to point to `deployment/scripts/README.md` instead of `scripts/dev/README.md`

## Testing
- `pytest -q` *(fails: command not found)*