### PR TITLE
Add deal linkage to quotes

### DIFF
--- a/tests/test_quote_deal_relationship.py
+++ b/tests/test_quote_deal_relationship.py
@@ -1,0 +1,46 @@
+import unittest
+from decimal import Decimal
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from warehouse_quote_app.app.database.session import Base
+from warehouse_quote_app.app.models.user import User
+from warehouse_quote_app.app.models.customer import Customer
+from warehouse_quote_app.app.models.crm import Deal, DealStage
+from warehouse_quote_app.app.models.quote import Quote
+
+class TestQuoteDealRelationship(unittest.TestCase):
+    def setUp(self):
+        engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(engine)
+        self.Session = sessionmaker(bind=engine)
+
+    def test_quote_associated_with_deal(self):
+        session = self.Session()
+        user = User(email="u@test.com", username="u", hashed_password="x")
+        customer = Customer(name="cust", email="c@test.com", phone="123", address="street")
+        session.add_all([user, customer])
+        session.commit()
+
+        deal = Deal(customer_id=customer.id, title="Deal", stage=DealStage.LEAD)
+        session.add(deal)
+        session.commit()
+
+        quote = Quote(
+            customer_id=customer.id,
+            total_amount=Decimal("10.00"),
+            service_type="storage",
+            created_by=user.id,
+            deal_id=deal.id,
+        )
+        session.add(quote)
+        session.commit()
+        session.refresh(quote)
+
+        self.assertEqual(quote.deal_id, deal.id)
+        self.assertIs(quote.deal, deal)
+        self.assertIn(quote, deal.quotes)
+        session.close()
+
+if __name__ == "__main__":
+    unittest.main()

--- a/warehouse_quote_app/alembic/versions/202407110000_add_deal_fk_to_quote.py
+++ b/warehouse_quote_app/alembic/versions/202407110000_add_deal_fk_to_quote.py
@@ -1,0 +1,19 @@
+"""Add deal relationship to quote"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "202407110000"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.add_column('quote', sa.Column('deal_id', sa.Integer(), nullable=True))
+    op.create_foreign_key('fk_quote_deal_id_deal', 'quote', 'deal', ['deal_id'], ['id'])
+
+
+def downgrade():
+    op.drop_constraint('fk_quote_deal_id_deal', 'quote', type_='foreignkey')
+    op.drop_column('quote', 'deal_id')
+

--- a/warehouse_quote_app/app/models/quote.py
+++ b/warehouse_quote_app/app/models/quote.py
@@ -47,9 +47,13 @@ class Quote(AsyncAttrs, StatusTrackingMixin, BaseModel):
     accepted_by: Mapped[Optional[int]] = mapped_column(ForeignKey("user.id"), nullable=True)
     rejected_by: Mapped[Optional[int]] = mapped_column(ForeignKey("user.id"), nullable=True)
     completed_by: Mapped[Optional[int]] = mapped_column(ForeignKey("user.id"), nullable=True)
+
+    # Deal association
+    deal_id: Mapped[Optional[int]] = mapped_column(ForeignKey("deal.id"), nullable=True)
     
     # Relationships
     customer: Mapped["Customer"] = relationship(back_populates="quotes")
+    deal: Mapped["Deal"] = relationship(back_populates="quotes")
     creator: Mapped["User"] = relationship(foreign_keys=[created_by], back_populates="created_quotes")
     acceptor: Mapped[Optional["User"]] = relationship(foreign_keys=[accepted_by], back_populates="accepted_quotes")
     rejector: Mapped[Optional["User"]] = relationship(foreign_keys=[rejected_by], back_populates="rejected_quotes")

--- a/warehouse_quote_app/app/schemas/quote.py
+++ b/warehouse_quote_app/app/schemas/quote.py
@@ -18,6 +18,7 @@ from warehouse_quote_app.app.models.quote import QuoteStatus
 class QuoteBase(BaseModel):
     """Base quote schema."""
     customer_id: int
+    deal_id: Optional[int] = None
     total_amount: Decimal
     service_type: str
     storage_requirements: Optional[Dict[str, Any]] = None
@@ -33,6 +34,7 @@ class QuoteUpdate(BaseModel):
     total_amount: Optional[Decimal] = None
     service_type: Optional[str] = None
     status: Optional[str] = None
+    deal_id: Optional[int] = None
     storage_requirements: Optional[Dict[str, Any]] = None
     transport_services: Optional[Dict[str, Any]] = None
     special_requirements: Optional[Dict[str, Any]] = None


### PR DESCRIPTION
## Summary
- link Quote records to CRM Deal via deal_id foreign key
- expose deal_id in Quote schemas
- create Alembic migration for new column
- test relationship between Quote and Deal

## Testing
- `python -m unittest tests/test_quote_deal_relationship.py -v` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*