### PR TITLE
Use apiClient for admin API

### DIFF
--- a/frontend/src/services/api/admin.ts
+++ b/frontend/src/services/api/admin.ts
@@ -1,18 +1,13 @@
-import axios from 'axios';
-
-const API_URL = import.meta.env.VITE_API_URL;
+import apiClient from './apiClient';
 
 export const fetchDashboardStats = async () => {
-  const { data } = await axios.get(`${API_URL}/api/admin/dashboard/stats`);
-  return data;
+  return apiClient.get('/admin/dashboard/stats');
 };
 
 export const fetchRecentQuotes = async () => {
-  const { data } = await axios.get(`${API_URL}/api/admin/quotes/recent`);
-  return data;
+  return apiClient.get('/admin/quotes/recent');
 };
 
 export const approveQuote = async (quoteId: string) => {
-  const { data } = await axios.post(`${API_URL}/api/admin/quotes/${quoteId}/approve`);
-  return data;
+  return apiClient.post(`/admin/quotes/${quoteId}/approve`);
 };

--- a/frontend/src/services/api/apiClient.ts
+++ b/frontend/src/services/api/apiClient.ts
@@ -67,7 +67,7 @@ export function createApiClient(config: ApiClientConfig): ApiClient {
 
 // Create and export the default API client
 const defaultClient = createApiClient({
-  baseURL: import.meta.env.VITE_API_URL,
+  baseURL: `${import.meta.env.VITE_API_URL}/api/v1`,
 });
 
 export default defaultClient;


### PR DESCRIPTION
## Summary
- use apiClient instead of axios in admin API service
- define /api/v1 base path in apiClient

## Testing
- `yarn install` *(fails: Workspace not found / network error)*