### PR TITLE
Implement CRM deal listing and frontend integration

### DIFF
--- a/frontend/src/components/crm/CustomerProfile/CustomerProfile.tsx
+++ b/frontend/src/components/crm/CustomerProfile/CustomerProfile.tsx
@@ -61,16 +61,15 @@ export const CustomerProfile: React.FC<CustomerProfileProps> = ({
   const loadCustomerData = async () => {
     setLoading(true);
     try {
-      const [customerStats, customerInteractions] = await Promise.all([
+      const [customerStats, customerInteractions, customerDeals] = await Promise.all([
         crmApi.getCustomerCRMStats(customerId),
-        crmApi.getCustomerInteractions(customerId)
+        crmApi.getCustomerInteractions(customerId),
+        crmApi.getCustomerDeals(customerId)
       ]);
       
       setStats(customerStats);
       setInteractions(customerInteractions);
-      
-      // TODO: Add API endpoint to get customer deals
-      setDeals([]);
+      setDeals(customerDeals);
     } catch (error) {
       message.error('Failed to load customer data');
     } finally {

--- a/frontend/src/services/api/crm.ts
+++ b/frontend/src/services/api/crm.ts
@@ -101,12 +101,22 @@ export const crmApi = {
     return response.data;
   },
 
+  getCustomerDeals: async (customerId: number): Promise<Deal[]> => {
+    const response = await apiClient.get(`/customers/${customerId}/deals`);
+    return response.data;
+  },
+
   updateDeal: async (dealId: number, data: {
     title?: string;
     stage?: DealStage;
     metadata?: Record<string, any>;
   }): Promise<Deal> => {
     const response = await apiClient.patch(`/deals/${dealId}`, data);
+    return response.data;
+  },
+
+  getDealsByStage: async (): Promise<Record<DealStage, Deal[]>> => {
+    const response = await apiClient.get('/deals/by-stage');
     return response.data;
   },
 

--- a/warehouse_quote_app/app/api/v1/endpoints/crm.py
+++ b/warehouse_quote_app/app/api/v1/endpoints/crm.py
@@ -1,5 +1,5 @@
 """CRM endpoints."""
-from typing import List, Optional
+from typing import List, Optional, Dict
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -125,3 +125,27 @@ def get_customers_with_crm_stats(
     """
     crm_service = CRMService(db)
     return crm_service.get_customers_with_crm_stats(db, skip=skip, limit=limit)
+
+
+@router.get("/customers/{customer_id}/deals", response_model=List[DealRead])
+async def get_customer_deals(
+    customer_id: int,
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(get_current_user),
+):
+    """List all deals for a customer."""
+    crm_service = CRMService(db)
+    try:
+        return await crm_service.get_customer_deals(customer_id)
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+
+
+@router.get("/deals/by-stage", response_model=Dict[DealStage, List[DealRead]])
+async def get_deals_grouped_by_stage(
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(get_current_user),
+):
+    """List all deals grouped by stage."""
+    crm_service = CRMService(db)
+    return await crm_service.get_deals_grouped_by_stage()


### PR DESCRIPTION
## Summary
- extend CRM service with deal listing helpers
- create endpoints for customer deals and deals grouped by stage
- expose `getCustomerDeals` and `getDealsByStage` in CRM API client
- fetch deals in CustomerProfile
- load KanbanBoard data from new deal endpoints

## Testing
- `pytest -q` *(fails: command not found)*
- `yarn test` *(fails: package not in lockfile)*