### PR TITLE
Add admin hooks and integrate rate/quote tables

### DIFF
--- a/frontend/src/components/admin/QuoteList/index.tsx
+++ b/frontend/src/components/admin/QuoteList/index.tsx
@@ -1,38 +1,65 @@
 import React from 'react';
-import { Card, Typography, Table } from 'antd';
+import { Card, Typography, Table, Space, Button, Popconfirm, Tag } from 'antd';
+import { useAdminQuotes, useApproveQuote, useDeleteAdminQuote } from '../../../hooks/useAdminQuotes';
+import { Quote } from '../../../types/quote';
 
 const { Title } = Typography;
 
 export const QuoteList: React.FC = () => {
+  const { data: quotes, isLoading } = useAdminQuotes();
+  const approveQuote = useApproveQuote();
+  const deleteQuote = useDeleteAdminQuote();
+
+  const columns = [
+    {
+      title: 'ID',
+      dataIndex: 'id',
+      key: 'id',
+    },
+    {
+      title: 'Customer',
+      dataIndex: 'customer_name',
+      key: 'customer_name',
+    },
+    {
+      title: 'Status',
+      dataIndex: 'status',
+      key: 'status',
+      render: (status: string) => <Tag>{status.toUpperCase()}</Tag>,
+    },
+    {
+      title: 'Created',
+      dataIndex: 'created_at',
+      key: 'created_at',
+      render: (date: string) => new Date(date).toLocaleDateString(),
+    },
+    {
+      title: 'Actions',
+      key: 'actions',
+      render: (record: Quote) => (
+        <Space>
+          {record.status !== 'approved' && (
+            <Button size="small" onClick={() => approveQuote.mutate(record.id)}>
+              Approve
+            </Button>
+          )}
+          <Popconfirm
+            title="Are you sure delete this quote?"
+            onConfirm={() => deleteQuote.mutate(record.id)}
+          >
+            <Button size="small" danger>
+              Delete
+            </Button>
+          </Popconfirm>
+        </Space>
+      ),
+    },
+  ];
+
   return (
     <Card>
       <Title level={2}>Admin Quote List</Title>
-      <p>This is a placeholder for the Admin Quote List component.</p>
-      <Table 
-        dataSource={[]}
-        columns={[
-          {
-            title: 'ID',
-            dataIndex: 'id',
-            key: 'id',
-          },
-          {
-            title: 'Client',
-            dataIndex: 'client',
-            key: 'client',
-          },
-          {
-            title: 'Status',
-            dataIndex: 'status',
-            key: 'status',
-          },
-          {
-            title: 'Created At',
-            dataIndex: 'createdAt',
-            key: 'createdAt',
-          },
-        ]}
-      />
+      <Table rowKey="id" loading={isLoading} dataSource={quotes} columns={columns} />
     </Card>
   );
 };

--- a/frontend/src/components/admin/RateManager/index.tsx
+++ b/frontend/src/components/admin/RateManager/index.tsx
@@ -1,39 +1,68 @@
 import React from 'react';
-import { Card, Typography, Table } from 'antd';
+import { Tag, Typography } from 'antd';
+import { CRUDManager } from '../../common/CRUDManager';
+import { RateForm } from '../forms/RateForm';
+import {
+  useAdminRates,
+  useCreateRate,
+  useUpdateRate,
+  useDeleteRate,
+} from '../../../hooks/useAdminRates';
+import { Rate } from '../../../types/rate';
 
-const { Title } = Typography;
+const { Text } = Typography;
+
+const columns = [
+  {
+    title: 'Name',
+    dataIndex: 'name',
+    key: 'name',
+    render: (text: string) => <Text strong>{text}</Text>,
+  },
+  {
+    title: 'Category',
+    dataIndex: 'category',
+    key: 'category',
+  },
+  {
+    title: 'Rate',
+    dataIndex: 'rate',
+    key: 'rate',
+    render: (value: number) => <Text>$ {value.toFixed(2)}</Text>,
+  },
+  {
+    title: 'Unit',
+    dataIndex: 'unit',
+    key: 'unit',
+  },
+  {
+    title: 'Status',
+    dataIndex: 'is_active',
+    key: 'is_active',
+    render: (active: boolean) => (
+      <Tag color={active ? 'green' : 'orange'}>{active ? 'ACTIVE' : 'INACTIVE'}</Tag>
+    ),
+  },
+];
 
 export const RateManager: React.FC = () => {
+  const createRate = useCreateRate();
+  const updateRate = useUpdateRate();
+  const deleteRate = useDeleteRate();
+
   return (
-    <Card>
-      <Title level={2}>Rate Manager</Title>
-      <p>This is a placeholder for the Rate Manager component.</p>
-      <Table 
-        dataSource={[]}
-        columns={[
-          {
-            title: 'ID',
-            dataIndex: 'id',
-            key: 'id',
-          },
-          {
-            title: 'Name',
-            dataIndex: 'name',
-            key: 'name',
-          },
-          {
-            title: 'Base Cost',
-            dataIndex: 'baseCost',
-            key: 'baseCost',
-          },
-          {
-            title: 'Status',
-            dataIndex: 'status',
-            key: 'status',
-          },
-        ]}
-      />
-    </Card>
+    <CRUDManager<Rate>
+      title="Rate Management"
+      useQuery={useAdminRates}
+      columns={columns}
+      createMutation={createRate.mutateAsync}
+      updateMutation={async ({ id, ...data }) => updateRate.mutateAsync({ id, data })}
+      deleteMutation={deleteRate.mutateAsync}
+      FormComponent={RateForm}
+      queryKey={['adminRates']}
+      addButtonText="Add Rate"
+      deleteConfirmText="Are you sure you want to delete this rate?"
+    />
   );
 };
 

--- a/frontend/src/components/admin/forms/RateForm.tsx
+++ b/frontend/src/components/admin/forms/RateForm.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { Form, Input, InputNumber, Select, Switch, Button, Space } from 'antd';
+import { Rate, RateInput } from '../../../types/rate';
+
+const { Option } = Select;
+
+export interface RateFormProps {
+  initialValues?: Partial<Rate>;
+  onSubmit: (values: RateInput | Partial<RateInput>) => void;
+  onCancel: () => void;
+}
+
+export const RateForm: React.FC<RateFormProps> = ({ initialValues, onSubmit, onCancel }) => {
+  const [form] = Form.useForm();
+
+  const handleFinish = (values: any) => {
+    onSubmit(values);
+  };
+
+  return (
+    <Form form={form} layout="vertical" initialValues={initialValues} onFinish={handleFinish}>
+      <Form.Item name="name" label="Name" rules={[{ required: true, message: 'Enter name' }]}> 
+        <Input />
+      </Form.Item>
+      <Form.Item name="description" label="Description">
+        <Input.TextArea rows={2} />
+      </Form.Item>
+      <Form.Item name="category" label="Category" rules={[{ required: true, message: 'Select category' }]}> 
+        <Select>
+          <Option value="storage">Storage</Option>
+          <Option value="handling">Handling</Option>
+          <Option value="additional">Additional</Option>
+          <Option value="container">Container</Option>
+          <Option value="transport">Transport</Option>
+          <Option value="export">Export</Option>
+        </Select>
+      </Form.Item>
+      <Form.Item name="rate" label="Rate" rules={[{ required: true, message: 'Enter rate' }]}> 
+        <InputNumber min={0} style={{ width: '100%' }} />
+      </Form.Item>
+      <Form.Item name="unit" label="Unit" rules={[{ required: true, message: 'Select unit' }]}> 
+        <Select>
+          <Option value="item">Item</Option>
+          <Option value="pallet">Pallet</Option>
+          <Option value="box">Box</Option>
+          <Option value="container">Container</Option>
+          <Option value="kg">Kg</Option>
+          <Option value="hour">Hour</Option>
+          <Option value="day">Day</Option>
+          <Option value="flat">Flat</Option>
+        </Select>
+      </Form.Item>
+      <Form.Item name="is_active" valuePropName="checked" label="Active">
+        <Switch />
+      </Form.Item>
+      <Form.Item>
+        <Space>
+          <Button onClick={onCancel}>Cancel</Button>
+          <Button type="primary" htmlType="submit">
+            {initialValues ? 'Update' : 'Create'}
+          </Button>
+        </Space>
+      </Form.Item>
+    </Form>
+  );
+};
+
+export default RateForm;

--- a/frontend/src/hooks/useAdminQuotes.ts
+++ b/frontend/src/hooks/useAdminQuotes.ts
@@ -1,0 +1,37 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import apiClient from '../services/api/client';
+import { Quote } from '../types/quote';
+
+const fetchQuotes = async (): Promise<Quote[]> => {
+  const { data } = await apiClient.get('/admin/quotes');
+  return data;
+};
+
+export const useAdminQuotes = () => {
+  return useQuery({ queryKey: ['adminQuotes'], queryFn: fetchQuotes });
+};
+
+export const useApproveQuote = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: number) => {
+      const { data } = await apiClient.post(`/admin/quotes/${id}/approve`);
+      return data as Quote;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['adminQuotes'] });
+    },
+  });
+};
+
+export const useDeleteAdminQuote = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: number) => {
+      await apiClient.delete(`/quotes/${id}`);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['adminQuotes'] });
+    },
+  });
+};

--- a/frontend/src/hooks/useAdminRates.ts
+++ b/frontend/src/hooks/useAdminRates.ts
@@ -1,0 +1,50 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import apiClient from '../services/api/client';
+import { Rate, RateInput } from '../types/rate';
+
+const fetchRates = async (): Promise<Rate[]> => {
+  const { data } = await apiClient.get('/admin/rates');
+  return data;
+};
+
+export const useAdminRates = () => {
+  return useQuery({ queryKey: ['adminRates'], queryFn: fetchRates });
+};
+
+export const useCreateRate = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (rate: RateInput) => {
+      const { data } = await apiClient.post('/admin/rates', rate);
+      return data as Rate;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['adminRates'] });
+    },
+  });
+};
+
+export const useUpdateRate = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, data }: { id: number; data: Partial<RateInput> }) => {
+      const response = await apiClient.put(`/admin/rates/${id}`, data);
+      return response.data as Rate;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['adminRates'] });
+    },
+  });
+};
+
+export const useDeleteRate = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: number) => {
+      await apiClient.delete(`/rate-cards/rates/${id}`);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['adminRates'] });
+    },
+  });
+};

--- a/frontend/src/services/api/admin.ts
+++ b/frontend/src/services/api/admin.ts
@@ -1,18 +1,18 @@
-import axios from 'axios';
+import apiClient from './client';
 
-const API_URL = import.meta.env.VITE_API_URL;
+// base URL is handled by apiClient
 
 export const fetchDashboardStats = async () => {
-  const { data } = await axios.get(`${API_URL}/api/admin/dashboard/stats`);
+  const { data } = await apiClient.get('/admin/dashboard/stats');
   return data;
 };
 
 export const fetchRecentQuotes = async () => {
-  const { data } = await axios.get(`${API_URL}/api/admin/quotes/recent`);
+  const { data } = await apiClient.get('/admin/quotes/recent');
   return data;
 };
 
 export const approveQuote = async (quoteId: string) => {
-  const { data } = await axios.post(`${API_URL}/api/admin/quotes/${quoteId}/approve`);
+  const { data } = await apiClient.post(`/admin/quotes/${quoteId}/approve`);
   return data;
 };

--- a/frontend/src/types/rate.ts
+++ b/frontend/src/types/rate.ts
@@ -1,0 +1,18 @@
+export interface Rate {
+  id: number;
+  name: string;
+  description?: string;
+  category: string;
+  rate: number;
+  unit: string;
+  is_active: boolean;
+}
+
+export interface RateInput {
+  name: string;
+  description?: string;
+  category: string;
+  rate: number;
+  unit: string;
+  is_active?: boolean;
+}


### PR DESCRIPTION
## Summary
- implement admin React Query hooks for rates and quotes
- wire RateManager and QuoteList to real data and actions
- use authenticated apiClient in admin api service
- add simple form and types for rates

## Testing
- `pytest -q` *(fails: command not found)*
- `npm test --silent` *(fails: jest not found)*