### PR TITLE
Implement admin login token generation

### DIFF
--- a/warehouse_quote_app/app/api/v1/endpoints/admin.py
+++ b/warehouse_quote_app/app/api/v1/endpoints/admin.py
@@ -87,14 +87,38 @@ class LoginCredentials(BaseModel):
     email: str
     password: str
 
+class SSOLoginCredentials(BaseModel):
+    provider: str
+    token: str
+
 @router.post("/admin/login")
 async def admin_login(
     credentials: LoginCredentials,
     admin_service: AdminService = Depends(get_admin_service)
-) -> Dict[str, str]:
+) -> Dict[str, Any]:
     """Login as admin user."""
-    token = await admin_service.login(credentials.email, credentials.password)
-    return {"access_token": token, "token_type": "bearer"}
+    token, user = await admin_service.login(credentials.email, credentials.password)
+    return {
+        "access_token": token,
+        "token_type": "bearer",
+        "user_id": user.id,
+        "is_admin": user.is_admin,
+    }
+
+
+@router.post("/admin/sso-login")
+async def admin_sso_login(
+    credentials: SSOLoginCredentials,
+    admin_service: AdminService = Depends(get_admin_service)
+) -> Dict[str, Any]:
+    """Login using an SSO token."""
+    token, user = await admin_service.sso_login(credentials.provider, credentials.token)
+    return {
+        "access_token": token,
+        "token_type": "bearer",
+        "user_id": user.id,
+        "is_admin": user.is_admin,
+    }
 
 @router.get("/admin/metrics", response_model=AdminMetricsResponse)
 async def get_metrics(

--- a/warehouse_quote_app/app/services/__init__.py
+++ b/warehouse_quote_app/app/services/__init__.py
@@ -38,4 +38,7 @@ __all__ = [
     'ConversationState',
     'ConversationContext',
     'ConversationResponse'
+    'SSOProvider',
 ]
+
+from .sso import SSOProvider

--- a/warehouse_quote_app/app/services/sso.py
+++ b/warehouse_quote_app/app/services/sso.py
@@ -1,0 +1,14 @@
+class SSOProvider:
+    """Placeholder service for verifying SSO tokens."""
+
+    def verify_token(self, provider: str, token: str) -> dict:
+        """Verify a token with the given provider and return user info.
+
+        This is a simplified placeholder implementation. Real SSO integration
+        should validate the token using the provider's SDK or API.
+        """
+        # TODO: Implement real SSO verification
+        if not token:
+            raise ValueError("Invalid SSO token")
+        # For demo purposes, just return a fake user payload
+        return {"email": token, "provider": provider}


### PR DESCRIPTION
## Summary
- return JWT tokens instead of dummy strings in `AdminService.login`
- expose user info in `/admin/login` response
- add placeholder SSO provider and `/admin/sso-login` endpoint

## Testing
- `pytest -q` *(fails: command not found)*